### PR TITLE
Fix variables in Danish translation

### DIFF
--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -131,7 +131,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+0"/>
         <source>Could not write to file %1.</source>
-        <translation>Kunne ikke skrive til fil% 1.</translation>
+        <translation>Kunne ikke skrive til fil %1.</translation>
     </message>
 </context>
 <context>
@@ -511,7 +511,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+488"/>
         <source>Staking.&lt;br&gt;Your weight is %1&lt;br&gt;Network weight is %2&lt;br&gt;Expected time to earn reward is %3</source>
-        <translation>Renter.&lt;br&gt; Din andel er% 1 &lt;br&gt; Netværkets andel er% 2 &lt;br&gt; Forventet tid til at modtage rente %3</translation>
+        <translation>Renter.&lt;br&gt; Din andel er %1 &lt;br&gt; Netværkets andel er %2 &lt;br&gt; Forventet tid til at modtage rente %3</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -1872,7 +1872,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+1"/>
         <source>Are you sure you want to send %1?</source>
-        <translation>Er du sikker på du vil sende% 1?</translation>
+        <translation>Er du sikker på du vil sende %1?</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -2424,7 +2424,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation>Bekræftelse (% 1 af% 2 anbefalede bekræftelser)</translation>
+        <translation>Bekræftelse (%1 af %2 anbefalede bekræftelser)</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -2434,7 +2434,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+3"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation>Umodne (% 1 bekræftelser, vil være tilgængelige efter% 2)</translation>
+        <translation>Umodne (%1 bekræftelser, vil være tilgængelige efter %2)</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -2658,7 +2658,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+0"/>
         <source>Could not write to file %1.</source>
-        <translation>Kunne ikke skrive til filen% 1.</translation>
+        <translation>Kunne ikke skrive til filen %1.</translation>
     </message>
     <message>
         <location line="+100"/>
@@ -2894,7 +2894,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Deviant Alert&quot; admin@foo.
     <message>
         <location line="+89"/>
         <source>Invalid -tor address: &apos;%s&apos;</source>
-        <translation>Ugyldig-tor-adresse: &apos;% s&apos;</translation>
+        <translation>Ugyldig-tor-adresse: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -3111,7 +3111,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Deviant Alert&quot; admin@foo.
     <message>
         <location line="+2"/>
         <source>Execute command when a relevant alert is received (%s in cmd is replaced by message)</source>
-        <translation>Udfør kommando, når en relevant advarsel er modtaget (% s i cmd erstattes af meddelelse)</translation>
+        <translation>Udfør kommando, når en relevant advarsel er modtaget (%s i cmd erstattes af meddelelse)</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -3186,7 +3186,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Deviant Alert&quot; admin@foo.
     <message>
         <location line="+104"/>
         <source>Wallet %s resides outside data directory %s.</source>
-        <translation>Wallet% s placeret udenfor data mappe% s.</translation>
+        <translation>Wallet %s placeret udenfor data mappe %s.</translation>
     </message>
     <message>
         <location line="+37"/>
@@ -3291,7 +3291,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Deviant Alert&quot; admin@foo.
     <message>
         <location line="+125"/>
         <source>Unable to bind to %s on this computer. Deviant is probably already running.</source>
-        <translation>Kunne ikke binde sig til% s på denne computer. Deviant kører sikkert allerede.</translation>
+        <translation>Kunne ikke binde sig til %s på denne computer. Deviant kører sikkert allerede.</translation>
     </message>
     <message>
         <location line="-101"/>
@@ -3326,7 +3326,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Deviant Alert&quot; admin@foo.
     <message>
         <location line="+5"/>
         <source>Invalid amount for -mininput=&lt;amount&gt;: &apos;%s&apos;</source>
-        <translation>Ugyldigt beløb for-mininput = &lt;beløb&gt;: &apos;% s&apos;</translation>
+        <translation>Ugyldigt beløb for-mininput = &lt;beløb&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+3"/>


### PR DESCRIPTION
Fix many variables wrongly written.
Example: "% 1" instead of "%1"

But I don't know how to compile the .qm file